### PR TITLE
Viper - use yarn to run apps

### DIFF
--- a/src/viper/docker/image/node/root/etc/supervisor/conf.d/client.conf.twig
+++ b/src/viper/docker/image/node/root/etc/supervisor/conf.d/client.conf.twig
@@ -1,5 +1,8 @@
 [program:client]
-directory=/app/app/client
+directory=/app
+stopasgroup=true
+killasgroup=true
+stopsignal=TERM
 {% if @('app.dynamic') == 'yes' %}
 command=yarn dev
 {% else %}

--- a/src/viper/docker/image/node/root/etc/supervisor/conf.d/client.conf.twig
+++ b/src/viper/docker/image/node/root/etc/supervisor/conf.d/client.conf.twig
@@ -4,9 +4,9 @@ stopasgroup=true
 killasgroup=true
 stopsignal=TERM
 {% if @('app.dynamic') == 'yes' %}
-command=yarn dev
+command=yarn workspace @inviqa/viper-app-client dev
 {% else %}
-command=yarn start
+command=yarn workspace @inviqa/viper-app-client start
 {% endif %}
 user=node
 environment=HOME="/home/node",USER="node"

--- a/src/viper/docker/image/node/root/etc/supervisor/conf.d/client.conf.twig
+++ b/src/viper/docker/image/node/root/etc/supervisor/conf.d/client.conf.twig
@@ -1,11 +1,12 @@
 [program:client]
 directory=/app/app/client
 {% if @('app.dynamic') == 'yes' %}
-command=node ./node_modules/.bin/next dev
+command=yarn dev
 {% else %}
-command=node ./node_modules/.bin/next start
+command=yarn start
 {% endif %}
 user=node
+environment=HOME="/home/node",USER="node"
 autostart=%(ENV_SUPERVISOR_START_CLIENT)s
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0

--- a/src/viper/docker/image/node/root/etc/supervisor/conf.d/gateway.conf
+++ b/src/viper/docker/image/node/root/etc/supervisor/conf.d/gateway.conf
@@ -3,7 +3,7 @@ directory=/app
 stopasgroup=true
 killasgroup=true
 stopsignal=TERM
-command=yarn start
+command=yarn workspace @inviqa/viper-app-gateway start
 user=node
 environment=HOME="/home/node",USER="node"
 autostart=%(ENV_SUPERVISOR_START_GATEWAY)s

--- a/src/viper/docker/image/node/root/etc/supervisor/conf.d/gateway.conf
+++ b/src/viper/docker/image/node/root/etc/supervisor/conf.d/gateway.conf
@@ -1,7 +1,8 @@
 [program:gateway]
 directory=/app/app/gateway
-command=node dist/src/main.dev.js
+command=yarn start
 user=node
+environment=HOME="/home/node",USER="node"
 autostart=%(ENV_SUPERVISOR_START_GATEWAY)s
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0

--- a/src/viper/docker/image/node/root/etc/supervisor/conf.d/gateway.conf
+++ b/src/viper/docker/image/node/root/etc/supervisor/conf.d/gateway.conf
@@ -1,5 +1,8 @@
 [program:gateway]
-directory=/app/app/gateway
+directory=/app
+stopasgroup=true
+killasgroup=true
+stopsignal=TERM
 command=yarn start
 user=node
 environment=HOME="/home/node",USER="node"


### PR DESCRIPTION
* update client start scripts to `yarn dev` and `yarn start`
* update gateway start script to `yarn dev`

Not accessing node_modules directly gives us the flexibility to move to PnP if we wanted to (although many more changes would be needed of course)