### PR TITLE
VIPER-557 - avoid client builds when dynamic

### DIFF
--- a/src/viper/harness.yml
+++ b/src/viper/harness.yml
@@ -49,7 +49,10 @@ attributes:
       - run yarn install
       - run yarn generate:types
       - run yarn build:deps
-      - run yarn run --cwd=app/client build:storybook
+      - |
+        if [ "$APP_DYNAMIC" == "no" ]; then
+          run yarn run --cwd=app/client build:storybook
+        fi
     resourcePrefix: ''
     gateway:
       build:
@@ -71,7 +74,10 @@ attributes:
       image: 
       build:
         steps:
-        - run yarn build:app:client
+        - |
+          if [ "$APP_DYNAMIC" == "no" ]; then
+            run yarn build:app:client
+          fi
       port: 3000
       resources:
         memory: 1024Mi


### PR DESCRIPTION
when in dynamic mode we don't need to build storybook or next.js because:

* next.js builds/hot reloads automatically when running `dev`
* storybook builds/hot reloads automatically when running `start-storybook` - and we don't even run this in workspace yet anyway

Based on previous Viper PR: https://github.com/inviqa/viper/pull/677/files