### PR TITLE
Update k8s Ingress to v1 and add optional ingressClassName

### DIFF
--- a/src/viper/helm/app/templates/client/ingress.yaml
+++ b/src/viper/helm/app/templates/client/ingress.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.app.client.ingress.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
 {{- if .Values.app.client.ingress.annotations }}
@@ -17,6 +17,9 @@ metadata:
 {{- end }}
   name: {{ .Values.app.resourcePrefix }}viper-client
 spec:
+  {{- with (pick .Values.app.client.ingress "ingressClassName" "tls") }}
+  {{- . | toYaml | nindent 2 }}
+  {{- end }}
   rules:
   {{- if .Values.app.client.ingress.hosts }}
   {{- range $host := .Values.app.client.ingress.hosts }}
@@ -24,13 +27,11 @@ spec:
       http:
         paths:
           - backend:
-              serviceName: {{ $.Values.app.resourcePrefix }}viper-client
-              servicePort: 80
+              service:
+                name: {{ $.Values.app.resourcePrefix }}viper-client
+                port:
+                  number: 80
   {{- end -}}
-  {{- end }}
-  {{- if .Values.app.client.ingress.tls }}
-  tls:
-  {{- toYaml .Values.app.client.ingress.tls | nindent 4 }}
   {{- end }}
 status:
   loadBalancer: {}

--- a/src/viper/helm/app/templates/client/ingress.yaml
+++ b/src/viper/helm/app/templates/client/ingress.yaml
@@ -26,7 +26,9 @@ spec:
     - host: {{ $host }}
       http:
         paths:
-          - backend:
+          - path: /
+            pathType: Prefix
+            backend:
               service:
                 name: {{ $.Values.app.resourcePrefix }}viper-client
                 port:

--- a/src/viper/helm/app/templates/gateway/ingress.yaml
+++ b/src/viper/helm/app/templates/gateway/ingress.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.app.gateway.ingress.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
 {{- if .Values.app.gateway.ingress.annotations }}
@@ -17,6 +17,9 @@ metadata:
 {{- end }}
   name: {{ .Values.app.resourcePrefix }}viper-gateway
 spec:
+  {{- with (pick .Values.app.gateway.ingress "ingressClassName" "tls") }}
+  {{- . | toYaml | nindent 2 }}
+  {{- end }}
   rules:
   {{- if .Values.app.gateway.ingress.hosts }}
   {{- range $host := .Values.app.gateway.ingress.hosts }}
@@ -24,13 +27,11 @@ spec:
       http:
         paths:
           - backend:
-              serviceName: {{ $.Values.app.resourcePrefix }}viper-gateway
-              servicePort: 80
+              service:
+                name: {{ $.Values.app.resourcePrefix }}viper-gateway
+                port:
+                  number: 80
   {{- end -}}
-  {{- end }}
-  {{- if .Values.app.gateway.ingress.tls }}
-  tls:
-  {{- toYaml .Values.app.gateway.ingress.tls | nindent 4 }}
   {{- end }}
 status:
   loadBalancer: {}

--- a/src/viper/helm/app/templates/gateway/ingress.yaml
+++ b/src/viper/helm/app/templates/gateway/ingress.yaml
@@ -26,7 +26,9 @@ spec:
     - host: {{ $host }}
       http:
         paths:
-          - backend:
+          - path: /
+            pathType: Prefix
+            backend:
               service:
                 name: {{ $.Values.app.resourcePrefix }}viper-gateway
                 port:


### PR DESCRIPTION
Needed for k8s 1.22, supported since 1.19, and requires ArgoCD > 1.8