### PR TITLE
Switch kubeval's k8s spec location to fork

### DIFF
--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -48,6 +48,9 @@ attributes.default:
     feature:
       sealed_secrets: true
 
+    # currently limited to versions supplied by https://github.com/inviqa/kubernetes-json-schema/tree/master/docs/schema
+    kubernetes_version: 1.21.9
+
     sealed_secrets:
       controller:
         name: sealed-secrets

--- a/src/_base/harness/config/pipeline.yml
+++ b/src/_base/harness/config/pipeline.yml
@@ -60,6 +60,7 @@ command('helm template <chart-path>'):
 command('helm kubeval <chart-path>'):
   env:
     CHART_PATH: = input.argument('chart-path')
+    K8S_VERSION: = @('helm.kubernetes_version')
     NAMESPACE: = @('pipeline.' ~ input.argument('environment') ~ '.namespace')
     ADDITIONAL_SCHEMA_LOCATIONS: = @('helm.additional_schema_locations')
   exec: |
@@ -75,7 +76,10 @@ command('helm kubeval <chart-path>'):
       passthru helm plugin remove kubeval
     fi
     passthru helm plugin install https://github.com/inviqa/helm-kubeval || true
-    KUBEVAL_OPTS=()
+    KUBEVAL_OPTS=(
+      --kubernetes-version "${K8S_VERSION}"
+      --schema-location https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master
+    )
     if [ -n "${ADDITIONAL_SCHEMA_LOCATIONS:-}" ]; then
       KUBEVAL_OPTS+=(--additional-schema-locations "${ADDITIONAL_SCHEMA_LOCATIONS}")
     fi

--- a/src/_base/harness/config/pipeline.yml
+++ b/src/_base/harness/config/pipeline.yml
@@ -77,6 +77,7 @@ command('helm kubeval <chart-path>'):
     fi
     passthru helm plugin install https://github.com/inviqa/helm-kubeval || true
     KUBEVAL_OPTS=(
+      --kube-version "${K8S_VERSION}"
       --kubernetes-version "${K8S_VERSION}"
       --schema-location https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master
     )


### PR DESCRIPTION
and limit it to a release before 1.22 to currently avoid it's obsoletions

https://github.com/instrumenta/kubernetes-json-schema hasn't been updated since 1.18.1 and we're using later versions now.

Since there are no obsoletions until 1.22, test against 1.21