### PR TITLE
Run weekly builds instead of nightly

### DIFF
--- a/src/_base/application/overlay/Jenkinsfile.twig
+++ b/src/_base/application/overlay/Jenkinsfile.twig
@@ -1,10 +1,10 @@
 pipeline {
-    agent { label "my127ws" }
+    agent { label 'linux-amd64' }
     environment {
         MY127WS_KEY = credentials('{{ @('jenkins.credentials.my127ws_key') }}')
         MY127WS_ENV = "pipeline"
     }
-    triggers { cron(env.BRANCH_NAME == '{{ @('git.main_branch') }}' ? 'H H(0-6) * * *' : '') }
+    triggers { cron(env.BRANCH_NAME == '{{ @('git.main_branch') }}' ? 'H H(2-6) * * 1' : '') }
     stages {
         stage('Build') {
             steps {
@@ -22,7 +22,7 @@ pipeline {
 {% if @('pipeline.publish.enabled') == 'yes' %}
         stage('Publish') {
             when { not { triggeredBy 'TimerTrigger' } }
-            steps { 
+            steps {
                 milestone(50)
                 sh 'ws app publish'
 {% if @('pipeline.publish.chart.enabled') %}


### PR DESCRIPTION
In an effort to reduce our electricity consumption and carbon usage, run builds once a week on a Monday morning rather than every morning.

2am to 6am seems best in terms of the renewable electricity mix based on https://electricityinfo.org/fuel-mix-last-24-hours/ and the forecast for London in https://electricityinfo.org/carbon-intensity-by-region/